### PR TITLE
disable tiered compilation for benchmark runs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,4 +10,5 @@
                  [com.twitter/carbonite "1.3.2"]
                  [cheshire "5.2.0"]
                  [criterium "0.4.1"]]
+  :jvm-opts ^:replace ["-server" "-Xmx1g"]
   :main test-serialize.core)


### PR DESCRIPTION
by default, leiningen sets the JVM up for startup time, via tiered
compilation (see https://github.com/technomancy/leiningen/wiki/Faster).

This doesn't play so well with benchmarks, so when running benchmarks,
you need to turn off tiered compilation. Plus, nearly all jvm servers
will run with `-server` and a larger heap size, so enable them as well.
